### PR TITLE
fix: user can kill xinetd process

### DIFF
--- a/linux/AKA/Dockerfile
+++ b/linux/AKA/Dockerfile
@@ -18,7 +18,6 @@ RUN chown -R root:ctf /ctf && \
     chmod -R 750 /ctf && \
     chmod 740 /ctf/flag.txt
 
-
 ENTRYPOINT []
 CMD ["/usr/sbin/xinetd", "-dontfork"]
 


### PR DESCRIPTION
Running xinetd process as root so ctf user cannot kill it.